### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,16 +6,16 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-CommandProcessor        KEYWORD1
-CmdHandler              KEYWORD1
+CommandProcessor	KEYWORD1
+CmdHandler	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-registerCmd             KEYWORD2
-unregisterCmd           KEYWORD2
-process                 KEYWORD2
+registerCmd	KEYWORD2
+unregisterCmd	KEYWORD2
+process	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords